### PR TITLE
Fix humanize_duration to support negative durations

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -112,7 +112,7 @@ class MainEvents(commands.Cog):
         embed = discord.Embed(color=0x417505, timestamp=datetime.datetime.utcnow())
         embed.set_author(name=f'{member} ({member.id})', icon_url=member.avatar_url)
         created_at = member.created_at.strftime(f'{new}%B %d, %Y %H:%M:%S UTC')
-        created_at += '' if not new else '\n' + utils.humanize_duration(member.created_at).replace('-', '') + ' ago'
+        created_at += '' if not new else '\n' + utils.humanize_duration(member.created_at)
         embed.add_field(name='Created at', value=created_at)
         embed.add_field(name='Mention', value=f'<@{member.id}>')
 

--- a/utils.py
+++ b/utils.py
@@ -497,7 +497,12 @@ def humanize_duration(duration):
             duration = datetime.datetime.utcnow() - datetime.timedelta(seconds=duration.total_seconds())
     diff_delta = duration - now
     diff = int(diff_delta.total_seconds())
-
+	
+    if diff < 0:
+      sign = "-"
+      diff = -diff
+    else: sign = ""
+	
     minutes, seconds = divmod(diff, 60)
     hours, minutes = divmod(minutes, 60)
     days, hours = divmod(hours, 24)
@@ -519,7 +524,7 @@ def humanize_duration(duration):
                 expires.append('{} {}'.format(units[x], unit_strs[x]))
     
     if not expires: return '0 seconds'
-    return ', '.join(expires)
+    return sign + ', '.join(expires)
 
 async def mod_cmd_invoke_delete(channel):
     if channel.id in config.showModCTX or channel.category_id in config.showModCTX:

--- a/utils.py
+++ b/utils.py
@@ -499,9 +499,9 @@ def humanize_duration(duration):
     diff = int(diff_delta.total_seconds())
 	
     if diff < 0:
-      sign = "-"
       diff = -diff
-    else: sign = ""
+      ago = ' ago'
+    else: ago = ''
 	
     minutes, seconds = divmod(diff, 60)
     hours, minutes = divmod(minutes, 60)
@@ -524,7 +524,7 @@ def humanize_duration(duration):
                 expires.append('{} {}'.format(units[x], unit_strs[x]))
     
     if not expires: return '0 seconds'
-    return sign + ', '.join(expires)
+    return ', '.join(expires) + ago
 
 async def mod_cmd_invoke_delete(channel):
     if channel.id in config.showModCTX or channel.category_id in config.showModCTX:


### PR DESCRIPTION
# Pull request template
Use this template for all contributions made for the repository.

Please indicate all that apply with a checkmark. To make a check, convert brackets below to `[x]`.

* [ ] **Feature implementation**
* [x] **Bug fix**
* [ ] **Code change/improvement**
* [ ] **String change (i.e. grammar/spelling error or an addition)**

***

## Describe what your pull request does
Fixes humanize_duration to support negative durations correctly, appending "ago" if negative

## Related issues and extra details
Fixes issue where new joins will show `(2 weeks) - duration` instead of `duration`
